### PR TITLE
BUGFIX: Correctly set uriPathSegment for hierarchy

### DIFF
--- a/Classes/Service/HierarchyService.php
+++ b/Classes/Service/HierarchyService.php
@@ -131,7 +131,7 @@ class HierarchyService
             $this->applyProperties($hierarchyLevelNodeTemplate, $hierarchyLevelConfiguration['properties'], $context);
         }
 
-        if ($hierarchyLevelNodeType->isOfType('Neos.Neos:Document') && !isset($this->properties['uriPathSegment'])) {
+        if ($hierarchyLevelNodeType->isOfType('Neos.Neos:Document') && !isset($hierarchyLevelConfiguration['properties']['uriPathSegment'])) {
             $hierarchyLevelNodeTemplate->setProperty('uriPathSegment', $hierarchyLevelNodeTemplate->getName());
         }
 


### PR DESCRIPTION
Previously the node name was always stored as URI path segment because the fallback check checked a property that wasn't set.