### PR TITLE
FEATURE: Allow multiple sorting instructions per node type

### DIFF
--- a/Classes/NodeSignalInterceptor.php
+++ b/Classes/NodeSignalInterceptor.php
@@ -48,8 +48,8 @@ class NodeSignalInterceptor
             $sortingInstructions = [$sortingInstructions];
         }
 
-        foreach ($sortingInstructions as $sortingInstructions_) {
-            $this->createArchivist()->organizeNode($node, $sortingInstructions_);
+        foreach ($sortingInstructions as $sortingInstruction) {
+            $this->createArchivist()->organizeNode($node, $sortingInstruction);
         }
     }
 

--- a/Classes/NodeSignalInterceptor.php
+++ b/Classes/NodeSignalInterceptor.php
@@ -42,7 +42,15 @@ class NodeSignalInterceptor
             return;
         }
 
-        $this->createArchivist()->organizeNode($node, $this->sortingInstructions[$node->getNodeType()->getName()]);
+        $sortingInstructions = $this->sortingInstructions[$node->getNodeType()->getName()];
+
+        if (array_key_exists('hierarchyRoot', $sortingInstructions)) {
+            $sortingInstructions = [$sortingInstructions];
+        }
+
+        foreach ($sortingInstructions as $sortingInstructions_) {
+            $this->createArchivist()->organizeNode($node, $sortingInstructions_);
+        }
     }
 
     /**
@@ -61,9 +69,7 @@ class NodeSignalInterceptor
             return;
         }
 
-        if (array_key_exists($node->getNodeType()->getName(), $this->sortingInstructions ?? [])) {
-            $this->createArchivist()->organizeNode($node, $this->sortingInstructions[$node->getNodeType()->getName()]);
-        }
+        $this->nodeAdded($node);
     }
 
     /**


### PR DESCRIPTION
In addition to

```yaml
PunktDe:
  Archivist:
    sortingInstructions:
      MyNode.Type:
        hierarchyRoot: # ...
```

you can now do this:

```yaml
PunktDe:
  Archivist:
    sortingInstructions:
      MyNode.Type:
        foo1:
          hierarchyRoot:  # ...
        foo2:
          hierarchyRoot:  # ...
```